### PR TITLE
Thresholding and rebuild updates.

### DIFF
--- a/seas/domains.py
+++ b/seas/domains.py
@@ -746,7 +746,7 @@ def threshold_by_domains(components: dict,
     # Filter component timecourses
     timecourses = eig_mix.T
     lpf_timecourses = np.zeros_like(timecourses)
-    for index in range(timecourses.shape[1]):
+    for index in range(timecourses.shape[0]):
         lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
     
     output['masks'] = mask

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -733,7 +733,7 @@ def threshold_by_domains(components: dict,
                 eigenmask.flat[maskind] = mask.T[index]
                 filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
                 eigenbrain.flat[maskind] = filtered.flat
-                blurred = cv2.GaussianBlur(eigenbrain.flat, (blur, blur), 0)
+                blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
                 mask.T[index] = blurred.flat[maskind]
             else:
                 eigenbrain.flat = mask.T[index]

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -16,6 +16,7 @@ from seas.ica import rebuild_mean_roi_timecourse, filter_mean
 from seas.rois import make_mask
 from seas.colormaps import save_colorbar, REGION_COLORMAP, DEFAULT_COLORMAP
 
+from skimage.morphology import remove_small_objects
 
 def get_domain_map(components: dict,
                    blur: int = 21,
@@ -622,6 +623,7 @@ def rolling_mosaic_movie(domain_ROIs: np.ndarray,
 
 def threshold_by_domains(components: dict,
                    blur: int = 1,
+                   min_mask_size: int = 64,
                    min_size_ratio: float = 0.1,
                    map_only: bool = True,
                    apply_filter_mean: bool = True,
@@ -691,10 +693,28 @@ def threshold_by_domains(components: dict,
             print('no noise components found')
             signal_indices = np.where(artifact_components == 0)[0]
         # eig_vec = eig_vec[:, signal_indices] # Don't change number of ICs, we're updating back to dict
-
-    threshold_vec = components['eig_vec'].copy()
-    mask = np.zeros_like(eig_vec, dtype=bool)
     
+    mask = np.zeros_like(eig_vec, dtype=bool)
+
+    match thresh_type:
+        case 'max':
+            # Return indices across each eig_vec (loading vector for component) where loading is max
+            threshold_ROIs_vector = np.argmax(np.abs(eig_vec), axis=1)
+            # Then threshold by clearing eig_vec outside of max indices
+            mask[np.arange(eig_vec.shape[0]), threshold_ROIs_vector] = True
+        case 'percentile':
+            flipped = components['flipped']
+            # Flip ICs where necessary using flipped from dict
+            flipped_threshold_vec = np.multiply(flipped, eig_vec)
+            # Calculate 95 percentile cutoff for each IC
+            cutoff_vector = np.percentile(flipped, 0.95, axis=1)
+            # Mask for all values above cutoff
+            for i in np.arange(eig_vec.shape[0]):
+                mask[i, :] = flipped_threshold_vec[i] > cutoff_vector[i]
+        case _:
+            print("Threshold type is neither max nor percentile.")
+
+    # Filter small mask ROIs and smooth using blur
     if blur:
         print('blurring domains...')
         assert type(blur) is int, 'blur was not valid'
@@ -704,34 +724,18 @@ def threshold_by_domains(components: dict,
         eigenbrain = np.empty(shape)
         eigenbrain[:] = np.NAN
 
-        for index in range(threshold_vec.shape[1]):
+        for index in range(mask.shape[1]):
 
             if roimask is not None:
-                eigenbrain.flat[maskind] = threshold_vec.T[index]
-                blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                threshold_vec.T[index] = blurred.flat[maskind]
+                eigenbrain.flat[maskind] = mask.T[index]
+                filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)
+                blurred = cv2.GaussianBlur(filtered, (blur, blur), 0)
+                mask.T[index] = blurred.flat[maskind]
             else:
-                eigenbrain.flat = threshold_vec.T[index]
-                blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                threshold_vec.T[index] = blurred.flat
-
-    match thresh_type:
-        case 'max':
-            # Return indices across each eig_vec (loading vector for component) where loading is max
-            domain_ROIs_vector = np.argmax(np.abs(threshold_vec), axis=1)
-            # Then threshold by clearing eig_vec outside of max indices
-            mask[np.arange(threshold_vec.shape[0]), domain_ROIs_vector] = True
-        case 'percentile':
-            flipped = components['flipped']
-            # Flip ICs where necessary using flipped from dict
-            flipped_threshold_vec = np.multiply(flipped, threshold_vec)
-            # Calculate 95 percentile cutoff for each IC
-            cutoff_vector = np.percentile(flipped_threshold_vec, 0.95, axis=1)
-            # Mask for all values above cutoff
-            for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = flipped_threshold_vec[i] > cutoff_vector[i]
-        case _:
-            print("Threshold type is neither max nor percentile.")
+                eigenbrain.flat = mask.T[index]
+                filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)
+                blurred = cv2.GaussianBlur(filtered, (blur, blur), 0)
+                mask.T[index] = blurred.flat
 
     eig_vec[~mask] = 0
     output['masks'] = mask

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -721,8 +721,8 @@ def threshold_by_domains(components: dict,
         if blur % 2 != 1:
             blur += 1
 
-        eigenbrain = np.empty(shape)
-        eigenbrain[:] = np.NAN
+        eigenbrain = np.zeros(shape, dtype=bool)
+        # eigenbrain[:] = np.NAN
 
         for index in range(mask.shape[1]):
 

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -671,7 +671,7 @@ def threshold_by_domains(components: dict,
     output['domain_blur'] = blur
 
     eig_vec = components['eig_vec'].copy()
-    # eig_mix = components['eig_mix'].copy()
+    eig_mix = components['eig_mix'].copy()
     shape = components['shape']
     shape = (shape[1], shape[2])
 
@@ -732,10 +732,10 @@ def threshold_by_domains(components: dict,
             if roimask is not None:
                 eigenmask.flat[maskind] = mask.T[index]
                 filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
-                filtered_float = filtered.astype(np.float32)
-                eigenbrain.flat[maskind] = filtered_float.flat
-                blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                mask.T[index] = blurred.flat[maskind]
+                # filtered_float = filtered.astype(np.float32)
+                # eigenbrain.flat[maskind] = filtered_float.flat
+                # blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
+                mask.T[index] = filtered.flat[maskind]
             else:
                 eigenbrain.flat = mask.T[index]
                 filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)
@@ -748,14 +748,14 @@ def threshold_by_domains(components: dict,
     # readdition of the mean? Maybe as part of seas.ica.rebuild?
 
     # Filter component timecourses
-    # timecourses = eig_mix.T
-    # lpf_timecourses = np.zeros_like(timecourses)
-    # for index in range(timecourses.shape[0]):
-    #     lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+    timecourses = eig_mix.T
+    lpf_timecourses = np.zeros_like(timecourses)
+    for index in range(timecourses.shape[0]):
+        lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
     
     output['masks'] = mask
     output['eig_vec'] = eig_vec
-    # output['eig_mix'] = lpf_timecourses.T
+    output['eig_mix'] = lpf_timecourses.T
 
     return output
 

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -732,9 +732,9 @@ def threshold_by_domains(components: dict,
             if roimask is not None:
                 eigenmask.flat[maskind] = mask.T[index]
                 filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
-                eigenbrain.flat = filtered.flat
+                eigenbrain.flat[maskind] = filtered.flat.astype(np.float32)
                 blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                mask.T[index] = blurred.flat
+                mask.T[index] = blurred.flat[maskind]
             else:
                 eigenbrain.flat = mask.T[index]
                 filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -628,6 +628,7 @@ def threshold_by_domains(components: dict,
                    min_size_ratio: float = 0.1,
                    map_only: bool = True,
                    apply_filter_mean: bool = True,
+                   apply_component_filter: bool = False,
                    max_loops: int = 2,
                    ignore_small: bool = True,
                    thresh_type: str = 'max'):
@@ -671,7 +672,7 @@ def threshold_by_domains(components: dict,
     output['domain_blur'] = blur
 
     eig_vec = components['eig_vec'].copy()
-    eig_mix = components['eig_mix'].copy()
+
     shape = components['shape']
     shape = (shape[1], shape[2])
 
@@ -744,19 +745,18 @@ def threshold_by_domains(components: dict,
 
     eig_vec[~mask] = 0
 
-    # The following filtering isn't working, needs to be in its own function after 
-    # readdition of the mean? Maybe as part of seas.ica.rebuild?
-
     # Filter component timecourses
-    timecourses = eig_mix.T
-    lpf_timecourses = np.zeros_like(timecourses)
-    for index in range(timecourses.shape[0]):
-        lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+    if apply_component_filter:
+        eig_mix = components['eig_mix'].copy()
+        timecourses = eig_mix.T
+        lpf_timecourses = np.zeros_like(timecourses)
+        for index in range(timecourses.shape[0]):
+            lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+        output['eig_mix'] = lpf_timecourses.T
     
     output['masks'] = mask
     output['eig_vec'] = eig_vec
-    output['eig_mix'] = lpf_timecourses.T
-
+    
     return output
 
     # if blur:

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -751,7 +751,7 @@ def threshold_by_domains(components: dict,
         timecourses = eig_mix.T
         lpf_timecourses = np.zeros_like(timecourses)
         for index in range(timecourses.shape[0]):
-            lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+            lpf_timecourses[index] = butterworth(timecourses[index], high=0.5)
         output['eig_mix'] = lpf_timecourses.T
     
     output['masks'] = mask

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -708,8 +708,8 @@ def threshold_by_domains(components: dict,
             # Then threshold by clearing eig_vec outside of max indices
             mask[np.arange(eig_vec.shape[0]), threshold_ROIs_vector] = True
         case 'z-score':
-            mean_ROIs_vector = np.nanmean(eig_vec, axis=1)
-            std_ROIs_vector = np.nanstd(eig_vec, axis=1)
+            mean_ROIs_vector = np.nanmean(eig_vec, axis=0)
+            std_ROIs_vector = np.nanstd(eig_vec, axis=0)
             z_ROIs_vector = (eig_vec - mean_ROIs_vector)/std_ROIs_vector
             for i in np.arange(eig_vec.shape[0]):
                 mask[i, :] = np.abs(z_ROIs_vector[i]) > thresh_param

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -721,15 +721,17 @@ def threshold_by_domains(components: dict,
         if blur % 2 != 1:
             blur += 1
 
-        eigenbrain = np.zeros(shape, dtype=bool)
-        # eigenbrain[:] = np.NAN
+        eigenmask = np.zeros(shape, dtype=bool)
+        eigenbrain = np.empty(shape)
+        eigenbrain[:] = np.NAN
 
         for index in range(mask.shape[1]):
 
             if roimask is not None:
-                eigenbrain.flat[maskind] = mask.T[index]
-                filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)
-                blurred = cv2.GaussianBlur(filtered, (blur, blur), 0)
+                eigenmask.flat[maskind] = mask.T[index]
+                filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
+                eigenbrain.flat[maskind] = filtered.flat
+                blurred = cv2.GaussianBlur(eigenbrain.flat, (blur, blur), 0)
                 mask.T[index] = blurred.flat[maskind]
             else:
                 eigenbrain.flat = mask.T[index]

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -721,12 +721,6 @@ def threshold_by_domains(components: dict,
             # Then threshold by clearing eig_vec outside of max indices
             mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
             eig_vec[~mask] = 0
-        case 'mask':
-            # Return indices across each eig_vec (loading vector for component) where loading is max
-            domain_ROIs_vector = np.argmax(np.abs(eig_vec), axis=1)
-            # Then threshold by clearing eig_vec outside of max indices
-            mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
-            eig_vec = mask
         case 'percentile':
             flipped = components['flipped']
             # Flip ICs were necessary using flipped from dict
@@ -738,8 +732,9 @@ def threshold_by_domains(components: dict,
                 mask[i, :] = flipped_eig_vec[i] > cutoff_vector[i]
             eig_vec[~mask] = 0
         case _:
-            print("Threshold type is neither max, mask, nor percentile.")
-
+            print("Threshold type is neither max nor percentile.")
+    
+    output['masks'] = mask
     output['eig_vec'] = eig_vec
 
     return output

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -621,7 +621,6 @@ def rolling_mosaic_movie(domain_ROIs: np.ndarray,
     print('Saving Colorbar to:' + cbarpath)
     save_colorbar(scale, cbarpath, colormap=colormap)
 
-
 def threshold_by_domains(components: dict,
                    blur: int = 1,
                    min_mask_size: int = 64,

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -632,7 +632,8 @@ def threshold_by_domains(components: dict,
                    chigh: float = 0.5,
                    max_loops: int = 2,
                    ignore_small: bool = True,
-                   thresh_type: str = 'max'):
+                   thresh_type: str = 'max',
+                   thresh_param: float = None):
     '''
     Creates a domain map from extracted independent components.  A pixelwise maximum projection of the blurred signal components is taken through the n_components axis, to create a flattened representation of where a domain was maximally significant across the cortical surface.  Components with multiple noncontiguous significant regions are counted as two distinct domains.
 
@@ -706,6 +707,12 @@ def threshold_by_domains(components: dict,
             threshold_ROIs_vector = np.argmax(np.abs(eig_vec), axis=1)
             # Then threshold by clearing eig_vec outside of max indices
             mask[np.arange(eig_vec.shape[0]), threshold_ROIs_vector] = True
+        case 'z-score':
+            mean_ROIs_vector = np.nanmean(eig_vec, axis=1)
+            std_ROIs_vector = np.nanstd(eig_vec, axis=1)
+            z_ROIs_vector = (eig_vec - mean_ROIs_vector)/std_ROIs_vector
+            for i in np.arange(eig_vec.shape[0]):
+                mask[i, :] = np.abs(z_ROIs_vector[i]) > thresh_param
         case 'percentile':
             flipped = components['flipped']
             # Flip ICs where necessary using flipped from dict

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -15,6 +15,7 @@ from seas.video import save, rescale, rotate
 from seas.ica import rebuild_mean_roi_timecourse, filter_mean
 from seas.rois import make_mask
 from seas.colormaps import save_colorbar, REGION_COLORMAP, DEFAULT_COLORMAP
+from seas.signalanalysis import butterworth
 
 from skimage.morphology import remove_small_objects
 
@@ -670,6 +671,7 @@ def threshold_by_domains(components: dict,
     output['domain_blur'] = blur
 
     eig_vec = components['eig_vec'].copy()
+    eig_mix = components['eig_mix'].copy()
     shape = components['shape']
     shape = (shape[1], shape[2])
 
@@ -740,8 +742,16 @@ def threshold_by_domains(components: dict,
                 mask.T[index] = blurred.flat
 
     eig_vec[~mask] = 0
+
+    # Filter component timecourses
+    timecourses = eig_mix.T
+    lpf_timecourses = np.zeros_like(timecourses)
+    for index in range(timecourses.shape[1]):
+        lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+    
     output['masks'] = mask
     output['eig_vec'] = eig_vec
+    output['eig_mix'] = lpf_timecourses.T
 
     return output
 

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -721,6 +721,12 @@ def threshold_by_domains(components: dict,
             # Then threshold by clearing eig_vec outside of max indices
             mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
             eig_vec[~mask] = 0
+        case 'mask':
+            # Return indices across each eig_vec (loading vector for component) where loading is max
+            domain_ROIs_vector = np.argmax(np.abs(eig_vec), axis=1)
+            # Then threshold by clearing eig_vec outside of max indices
+            mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
+            eig_vec = mask
         case 'percentile':
             # Flip ICs were necessary using flipped from dict
             flipped_eig_vec = np.multiply(flipped, eig_vec)
@@ -731,7 +737,7 @@ def threshold_by_domains(components: dict,
                 mask[i, :] = flipped_eig_vec[i] > cutoff_vector[i]
             eig_vec[~mask] = 0
         case _:
-            print("Threshold type is neither max nor percentile.")
+            print("Threshold type is neither max, mask, nor percentile.")
 
     output['eig_vec'] = eig_vec
 

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -671,7 +671,7 @@ def threshold_by_domains(components: dict,
     output['domain_blur'] = blur
 
     eig_vec = components['eig_vec'].copy()
-    eig_mix = components['eig_mix'].copy()
+    # eig_mix = components['eig_mix'].copy()
     shape = components['shape']
     shape = (shape[1], shape[2])
 
@@ -732,9 +732,9 @@ def threshold_by_domains(components: dict,
             if roimask is not None:
                 eigenmask.flat[maskind] = mask.T[index]
                 filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
-                eigenbrain.flat[maskind] = filtered.flat
+                eigenbrain.flat = filtered.flat
                 blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                mask.T[index] = blurred.flat[maskind]
+                mask.T[index] = blurred.flat
             else:
                 eigenbrain.flat = mask.T[index]
                 filtered = remove_small_objects(eigenbrain, min_size=min_mask_size, connectivity=1)

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -97,7 +97,7 @@ def get_domain_map(components: dict,
             blur += 1
 
         eigenbrain = np.empty(shape)
-        eigenbrain[:] = np.NAN
+        eigenbrain[:] = np.nan
 
         for index in range(eig_vec.shape[1]):
 
@@ -117,7 +117,7 @@ def get_domain_map(components: dict,
 
     if roimask is not None:
         domain_ROIs = np.empty(shape)
-        domain_ROIs[:] = np.NAN
+        domain_ROIs[:] = np.nan
         domain_ROIs.flat[maskind] = domain_ROIs_vector
 
     else:
@@ -716,7 +716,7 @@ def threshold_by_domains(components: dict,
 
         eigenmask = np.zeros(shape, dtype=bool)
         eigenbrain = np.empty(shape)
-        eigenbrain[:] = np.NAN
+        eigenbrain[:] = np.nan
 
         for index in range(mask.shape[1]):
 
@@ -751,7 +751,7 @@ def threshold_by_domains(components: dict,
 
     # if roimask is not None:
     #     domain_ROIs = np.empty(shape)
-    #     domain_ROIs[:] = np.NAN
+    #     domain_ROIs[:] = np.nan
     #     domain_ROIs.flat[maskind] = domain_ROIs_vector
 
     # else:

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -692,6 +692,9 @@ def threshold_by_domains(components: dict,
             signal_indices = np.where(artifact_components == 0)[0]
         # eig_vec = eig_vec[:, signal_indices] # Don't change number of ICs, we're updating back to dict
 
+    threshold_vec = components['eig_vec'].copy()
+    mask = np.zeros_like(eig_vec, dtype=bool)
+    
     if blur:
         print('blurring domains...')
         assert type(blur) is int, 'blur was not valid'
@@ -701,39 +704,36 @@ def threshold_by_domains(components: dict,
         eigenbrain = np.empty(shape)
         eigenbrain[:] = np.NAN
 
-        for index in range(eig_vec.shape[1]):
+        for index in range(threshold_vec.shape[1]):
 
             if roimask is not None:
-                eigenbrain.flat[maskind] = eig_vec.T[index]
+                eigenbrain.flat[maskind] = threshold_vec.T[index]
                 blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                eig_vec.T[index] = blurred.flat[maskind]
+                threshold_vec.T[index] = blurred.flat[maskind]
             else:
-                eigenbrain.flat = eig_vec.T[index]
+                eigenbrain.flat = threshold_vec.T[index]
                 blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
-                eig_vec.T[index] = blurred.flat
+                threshold_vec.T[index] = blurred.flat
 
-    mask = np.zeros_like(eig_vec, dtype=bool)
-    
     match thresh_type:
         case 'max':
             # Return indices across each eig_vec (loading vector for component) where loading is max
-            domain_ROIs_vector = np.argmax(np.abs(eig_vec), axis=1)
+            domain_ROIs_vector = np.argmax(np.abs(threshold_vec), axis=1)
             # Then threshold by clearing eig_vec outside of max indices
-            mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
-            eig_vec[~mask] = 0
+            mask[np.arange(threshold_vec.shape[0]), domain_ROIs_vector] = True
         case 'percentile':
             flipped = components['flipped']
-            # Flip ICs were necessary using flipped from dict
-            flipped_eig_vec = np.multiply(flipped, eig_vec)
+            # Flip ICs where necessary using flipped from dict
+            flipped_threshold_vec = np.multiply(flipped, threshold_vec)
             # Calculate 95 percentile cutoff for each IC
-            cutoff_vector = np.percentile(flipped_eig_vec, 0.95, axis=1)
+            cutoff_vector = np.percentile(flipped_threshold_vec, 0.95, axis=1)
             # Mask for all values above cutoff
             for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = flipped_eig_vec[i] > cutoff_vector[i]
-            eig_vec[~mask] = 0
+                mask[i, :] = flipped_threshold_vec[i] > cutoff_vector[i]
         case _:
             print("Threshold type is neither max nor percentile.")
-    
+
+    eig_vec[~mask] = 0
     output['masks'] = mask
     output['eig_vec'] = eig_vec
 

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -732,7 +732,8 @@ def threshold_by_domains(components: dict,
             if roimask is not None:
                 eigenmask.flat[maskind] = mask.T[index]
                 filtered = remove_small_objects(eigenmask, min_size=min_mask_size, connectivity=1)
-                eigenbrain.flat[maskind] = filtered.flat.astype(np.float32)
+                filtered_float = filtered.astype(np.float32)
+                eigenbrain.flat[maskind] = filtered_float.flat
                 blurred = cv2.GaussianBlur(eigenbrain, (blur, blur), 0)
                 mask.T[index] = blurred.flat[maskind]
             else:

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -713,7 +713,7 @@ def threshold_by_domains(components: dict,
                 eig_vec.T[index] = blurred.flat
 
     mask = np.zeros_like(eig_vec, dtype=bool)
-    flipped = components['flipped']
+    
     match thresh_type:
         case 'max':
             # Return indices across each eig_vec (loading vector for component) where loading is max
@@ -722,6 +722,7 @@ def threshold_by_domains(components: dict,
             mask[np.arange(eig_vec.shape[0]), domain_ROIs_vector] = True
             eig_vec[~mask] = 0
         case 'percentile':
+            flipped = components['flipped']
             # Flip ICs were necessary using flipped from dict
             flipped_eig_vec = np.multiply(flipped, eig_vec)
             # Calculate 95 percentile cutoff for each IC

--- a/seas/domains.py
+++ b/seas/domains.py
@@ -743,15 +743,18 @@ def threshold_by_domains(components: dict,
 
     eig_vec[~mask] = 0
 
+    # The following filtering isn't working, needs to be in its own function after 
+    # readdition of the mean? Maybe as part of seas.ica.rebuild?
+
     # Filter component timecourses
-    timecourses = eig_mix.T
-    lpf_timecourses = np.zeros_like(timecourses)
-    for index in range(timecourses.shape[0]):
-        lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
+    # timecourses = eig_mix.T
+    # lpf_timecourses = np.zeros_like(timecourses)
+    # for index in range(timecourses.shape[0]):
+    #     lpf_timecourses[index] = butterworth(timecourses[index], high=1.0)
     
     output['masks'] = mask
     output['eig_vec'] = eig_vec
-    output['eig_mix'] = lpf_timecourses.T
+    # output['eig_mix'] = lpf_timecourses.T
 
     return output
 

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -523,6 +523,7 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     lag1 = components['lag1']
     lag1_full = components['lag1_full']
     noise = components['noise_components']
+    artifacts = components['artifact_components']
 
     if sort_by_noise:
         ev_sort = np.argsort(lag1) # Sorting by lag1 auto-correlation
@@ -534,6 +535,7 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     lag1 = lag1[ev_sort][::-1]
     lag1_full = lag1_full[ev_sort][::-1]
     noise = noise[ev_sort][::-1]
+    artifacts = artifacts[ev_sort][::-1]
     
     # Recalculation calls (how PySEAS does it originally)
     #noise, cutoff = sort_noise(eig_mix.T)
@@ -546,12 +548,13 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     components['lag1'] = lag1
     components['lag1_full'] = lag1_full
     components['noise_components'] = noise
+    components['artifact_components'] = artifacts
     # Derived
     components['timecourses'] = eig_mix.T
     
     # Recalculate domain map
-    domain_map = get_domain_map(components, map_only = False)
-    components.update(domain_map)
+    # domain_map = get_domain_map(components, map_only = False)
+    # components.update(domain_map)
 
     return components
 

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -550,8 +550,14 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     components['timecourses'] = eig_mix.T
     
     # Recalculate domain map
-    domain_map = get_domain_map(components, map_only = False)
+    domain_map = get_domain_map(components, map_only = True)
     components.update(domain_map)
+
+    if 'ROI_timecourses' in components:
+        print('Removing unsorted ROI_timecourses.')
+        del components['ROI_timecourses']
+    else:
+        print('ROI_timecourses not found. Skipping deletion.')
 
     return components
 

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -468,12 +468,14 @@ def export_event_masks(components: dict,
                        outpath: str,
                        blur: int = 3,
                        thresh_type: str = 'z-score',
-                       thresh_param: float = 7) -> None:
+                       thresh_param: float = 7,
+                       schematic: bool = False) -> None:
     components_copy = components.copy()
     threshold = threshold_by_domains(components_copy, 
                                      blur = blur, 
                                      thresh_type = thresh_type, 
-                                     thresh_param = thresh_param)
+                                     thresh_param = thresh_param,
+                                     schematic = schematic)
     components_copy.update(threshold)
     artifacts_bool = components_copy['artifact_components'].astype(bool)
     event_components = components_copy['eig_vec'][:, ~artifacts_bool]

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -523,7 +523,6 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     lag1 = components['lag1']
     lag1_full = components['lag1_full']
     noise = components['noise_components']
-    artifacts = components['artifact_components']
 
     if sort_by_noise:
         ev_sort = np.argsort(lag1) # Sorting by lag1 auto-correlation
@@ -535,7 +534,11 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     lag1 = lag1[ev_sort][::-1]
     lag1_full = lag1_full[ev_sort][::-1]
     noise = noise[ev_sort][::-1]
-    artifacts = artifacts[ev_sort][::-1]
+    
+    if 'artifact_components' in components:
+        artifacts = components['artifact_components']
+        artifacts = artifacts[ev_sort][::-1]
+        components['artifact_components'] = artifacts
     
     # Recalculation calls (how PySEAS does it originally)
     #noise, cutoff = sort_noise(eig_mix.T)
@@ -548,7 +551,7 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     components['lag1'] = lag1
     components['lag1_full'] = lag1_full
     components['noise_components'] = noise
-    components['artifact_components'] = artifacts
+    
     # Derived
     components['timecourses'] = eig_mix.T
     

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -475,7 +475,7 @@ def export_event_masks(components: dict,
                                      thresh_type = thresh_type, 
                                      thresh_param = thresh_param)
     components_copy.update(threshold)
-    artifacts_bool = components_copy['artifact_components'].astype(np.bool)
+    artifacts_bool = components_copy['artifact_components'].astype(bool)
     event_components = components_copy['eig_vec'][:, ~artifacts_bool]
     event_masks = rebuild_eigenbrain(event_components,
                                      roimask = components_copy['roimask'], 

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -540,11 +540,6 @@ def sort_components(components: dict, sort_by_noise: bool = True):
         artifacts = artifacts[ev_sort][::-1]
         components['artifact_components'] = artifacts
     
-    # Recalculation calls (how PySEAS does it originally)
-    #noise, cutoff = sort_noise(eig_mix.T)
-    #components['cutoff'] = cutoff
-    #components['lag1'] = lag_n_autocorr(components['timecourses'], 1)
-    
     # Save sorted values
     components['eig_vec'] = eig_vec
     components['eig_mix'] = eig_mix
@@ -552,10 +547,15 @@ def sort_components(components: dict, sort_by_noise: bool = True):
     components['lag1_full'] = lag1_full
     components['noise_components'] = noise
     
-    # Derived
+    # Derive from sorted values
     components['timecourses'] = eig_mix.T
     
-    # Recalculate domain map
+    # Recalculation calls (how PySEAS does it originally)
+    #noise, cutoff = sort_noise(eig_mix.T)
+    #components['cutoff'] = cutoff
+    #components['lag1'] = lag_n_autocorr(components['timecourses'], 1)
+
+    # Recalculate domain map (doesn't work for some reason)
     # domain_map = get_domain_map(components, map_only = False)
     # components.update(domain_map)
 

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -495,7 +495,8 @@ def export_event_video(components: dict,
                        cthresh: float = 2.0,
                        apply_masked_mean: bool = False,
                        filter_method: str = 'constant',
-                       include_noise: bool = True) -> None:
+                       include_noise: bool = True,
+                       binary_threshold: bool = False) -> None:
     components_copy = components.copy()
     threshold = threshold_by_domains(components_copy, 
                                      blur = 3, 
@@ -514,7 +515,8 @@ def export_event_video(components: dict,
                       cthresh = cthresh,
                       apply_masked_mean = apply_masked_mean,
                       filter_method = filter_method,
-                      include_noise = include_noise)
+                      include_noise = include_noise,
+                      binary_threshold = binary_threshold)
     tif.imwrite(outpath, rebuilt.astype(np.float32), imagej=True)
 
 def sort_components(components: dict, sort_by_noise: bool = True):

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -489,6 +489,9 @@ def export_event_masks(components: dict,
 def export_event_video(components: dict,
                        outpath: str,
                        artifact_components: np.ndarray = None,
+                       blur = 3,
+                       thresh_type = 'z-score',
+                       thresh_param = 7,
                        t_start: int = None,
                        t_stop: int = None,
                        apply_mean_filter: bool = True,
@@ -499,9 +502,9 @@ def export_event_video(components: dict,
                        binary_threshold: bool = False) -> None:
     components_copy = components.copy()
     threshold = threshold_by_domains(components_copy, 
-                                     blur = 3, 
-                                     thresh_type = 'z-score', 
-                                     thresh_param = 7)
+                                     blur = blur, 
+                                     thresh_type = thresh_type, 
+                                     thresh_param = thresh_param)
     eig_mix = filter_components(components_copy['eig_mix'])
     eig_mix = threshold_components(eig_mix, 
                                    thresh_param = cthresh)

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -506,8 +506,8 @@ def export_event_video(components: dict,
                                      thresh_type = thresh_type, 
                                      thresh_param = thresh_param)
     eig_mix = filter_components(components_copy['eig_mix'])
-    eig_mix = threshold_components(eig_mix, 
-                                   thresh_param = cthresh)
+    #eig_mix = threshold_components(eig_mix, 
+    #                               thresh_param = cthresh)
     components_copy.update(threshold)
     components_copy['eig_mix'] = eig_mix
     rebuilt = rebuild(components_copy,

--- a/seas/experiment.py
+++ b/seas/experiment.py
@@ -588,8 +588,9 @@ def flip_negative_components(components: dict):
             eig_mix[:, i] *= -1
             flipped[i] = -1
 
-    components['flipped'] = flipped
-    components['eig_vec'] = eig_vec
-    components['eig_mix'] = eig_mix
+    output = {}
+    output['flipped'] = flipped
+    output['eig_vec'] = eig_vec
+    output['eig_mix'] = eig_mix
 
-    return components
+    return output

--- a/seas/gui.py
+++ b/seas/gui.py
@@ -469,7 +469,7 @@ def run_gui(components: dict,
 
                     if component_id is None:  # Clear image.
                         im = np.empty((x, y))
-                        im[:] = np.NAN
+                        im[:] = np.nan
                         self.imgplot = self.ax.imshow(im)
                         self.canvas.draw()
                         return ()

--- a/seas/gui.py
+++ b/seas/gui.py
@@ -115,11 +115,11 @@ def run_gui(components: dict,
         print('initializing artifact_components toggle')
         toggle = np.zeros((n_components,), dtype='uint8')
 
-    if 'flipped' in components:
-        flipped = components['flipped']
+    # if 'flipped' in components:
+    #     flipped = components['flipped']
 
-        timecourses = timecourses * flipped[:, None]
-        eig_vec = eig_vec * flipped
+    #     timecourses = timecourses * flipped[:, None]
+    #     eig_vec = eig_vec * flipped
 
     if 'domain_ROIs' in components:
         domain_ROIs = components['domain_ROIs']

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -775,13 +775,13 @@ def threshold_by_domains(components: dict,
                                                                  [1,1,1],
                                                                  [0,1,0]])
             for j in range(num_features):
-                centroids = ndimage.center_of_mass(eigenbrain, 
+                centroid = ndimage.center_of_mass(eigenbrain, 
                                                    labels = labelled,
                                                    index = j)
-                int_centroids = [tuple(int(x) for x in y) for y in centroids]
+                int_centroid = tuple(int(x) for x in centroid)
                 event_size = np.sum(labelled, where = labelled == j)/j
                 schem_radius = int(np.sqrt(event_size/np.pi))
-                rr, cc = draw.disk(int_centroids[i], schem_radius, shape = shape)
+                rr, cc = draw.disk(int_centroid[i], schem_radius, shape = shape)
                 event_schematics[rr, cc] = 255
                 mask.T[i] = event_schematics.flat
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -749,7 +749,7 @@ def threshold_by_domains(components: dict,
             max_ROIs_vector = np.max(eig_vec, axis=0)
             print(f'max_ROIs_vector shape is: {max_ROIs_vector.shape}')
             for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = eig_vec[i, :] >= max_ROIs_vector[i]
+                mask[:, i] = eig_vec[:, i] >= max_ROIs_vector[i]
         case _:
             print("Threshold type is neither max nor percentile.")
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -376,7 +376,8 @@ def rebuild(components: dict,
     elif artifact_components == 'none':
         print('including all components')
         artifact_components = np.zeros(n_components)
-    elif ((not include_noise) and ('noise_components' in components.keys())):
+    
+    if ((not include_noise) and ('noise_components' in components.keys())):
         print('Not rebuilding noise components')
         artifact_components += components['noise_components']
         artifact_components[np.where(artifact_components > 1)] = 1

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -304,6 +304,7 @@ def rebuild(components: dict,
             t_start: int = None,
             t_stop: int = None,
             apply_mean_filter: bool = True,
+            apply_component_filter: bool = False,
             apply_masked_mean: bool = False,
             filter_method: str = 'wavelet',
             fps: float = 7.5,
@@ -387,6 +388,15 @@ def rebuild(components: dict,
         "Eigenvector size is not compatible with the masked region's size"
 
     eig_mix = components['eig_mix']
+
+    # Filter component timecourses
+    if apply_component_filter:
+        print('Filtering component timecourses using butterworth_lowpass at 0.5Hz...')
+        timecourses = eig_mix.T
+        lpf_timecourses = np.zeros_like(timecourses)
+        for index in range(timecourses.shape[0]):
+            lpf_timecourses[index] = butterworth(timecourses[index], high=0.5)
+        eig_mix = lpf_timecourses.T
 
     if (t_start == None):
         t_start = 0

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -748,7 +748,7 @@ def threshold_by_domains(components: dict,
         case 'max_value':
             max_ROIs_vector = np.max(eig_vec, axis=0)
             print(f'max_ROIs_vector shape is: {max_ROIs_vector.shape}')
-            for i in np.arange(eig_vec.shape[0]):
+            for i in np.arange(eig_vec.shape[1]):
                 mask[:, i] = eig_vec[:, i] >= max_ROIs_vector[i]
         case _:
             print("Threshold type is neither max nor percentile.")

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -744,6 +744,10 @@ def threshold_by_domains(components: dict,
             # Mask for all values above cutoff
             for i in np.arange(eig_vec.shape[0]):
                 mask[i, :] = flipped_threshold_vec[i] > cutoff_vector[i]
+        case 'max_value':
+            max_ROIs_vector = np.max(eig_vec, axis=0)
+            for i in np.arange(eig_vec.shape[0]):
+                mask[i, :] = eig_vec >= max_ROIs_vector
         case _:
             print("Threshold type is neither max nor percentile.")
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -697,7 +697,7 @@ def threshold_by_domains(components: dict,
             signal_indices = np.where(artifact_components == 0)[0]
         # eig_vec = eig_vec[:, signal_indices] # Don't change number of ICs, we're updating back to dict
     
-    mask = np.zeros_like(eig_vec, dtype=bool)
+    mask = np.zeros_like(eig_vec, dtype = bool)
 
     match thresh_type:
         case 'max':
@@ -713,8 +713,8 @@ def threshold_by_domains(components: dict,
                 abs_z = np.abs(z_ROIs_vector[i])
                 mask[i, :] = abs_z > thresh_param
                 if schematic:
-                    abs_z = abs_z[mask[i, :]]
-                    schem_thresh = np.percentile(abs_z, 75) 
+                    event = abs_z[mask[i, :]]
+                    schem_thresh = np.percentile(event, 75) 
                     mask[i, :] = abs_z > schem_thresh
         case 'percentile':
             flipped = components['flipped']

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -451,6 +451,9 @@ def rebuild(components: dict,
     print('\nReconstructing....')
     data_r = np.dot(eig_vec[:, reconstruct_indices],
                     eig_mix[t_start:t_stop, reconstruct_indices].T).T
+    
+    spatiotemporal_event_masks = np.bool(data_r)
+    spatiotemporal_event_masks[data_r > 0] = True
 
     if apply_masked_mean:
         masks = components['thresh_masks']
@@ -462,7 +465,7 @@ def rebuild(components: dict,
             mean_to_add = np.zeros_like(data_r)
             mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
             mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
-            data_r += mean_to_add
+            data_r += mean_to_add[spatiotemporal_event_masks]
 
         else:
             print('Not filtering mean')
@@ -470,7 +473,7 @@ def rebuild(components: dict,
             mean_to_add = np.zeros_like(data_r)
             mean_filtered = None
             mean_to_add[:, combined_mask] = mean[t_start:t_stop, None]
-            data_r += mean_to_add
+            data_r += mean_to_add[spatiotemporal_event_masks]
     else:
         # Run original readdition of mean
         if apply_mean_filter:

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -712,8 +712,8 @@ def threshold_by_domains(components: dict,
             for i in np.arange(eig_vec.shape[0]):
                 abs_z = np.abs(z_ROIs_vector[i])
                 mask[i, :] = abs_z > thresh_param
-                if schematic and abs_z.size != 0:
-                    event = abs_z[mask[i, :]]
+                event = abs_z[mask[i, :]]
+                if schematic and event.size != 0:
                     schem_thresh = np.percentile(event, 75) 
                     mask[i, :] = abs_z > schem_thresh
         case 'percentile':

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -323,6 +323,7 @@ def rebuild(components: dict,
             apply_component_threshold: bool = False,
             cthresh: float = 2.0,
             apply_masked_mean: bool = False,
+            binary_threshold: bool = False,
             filter_method: str = 'butterworth_highpass',
             fps: float = 7.5,
             include_noise: bool = True):
@@ -480,6 +481,11 @@ def rebuild(components: dict,
             print('Not filtering mean')
             mean_filtered = None
             data_r += mean[t_start:t_stop, None]
+
+    if binary_threshold:
+        data_binary = np.zeros(data_r)
+        data_binary(data_r > 0) = 255
+        data_r = data_binary
 
     print('Done!')
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -728,9 +728,9 @@ def threshold_by_domains(components: dict,
             mean_ROIs_vector = np.nanmean(eig_vec, axis=0)
             std_ROIs_vector = np.nanstd(eig_vec, axis=0)
             z_ROIs_vector = (eig_vec - mean_ROIs_vector)/std_ROIs_vector
-            for i in np.arange(eig_vec.shape[0]):
-                abs_z = np.abs(z_ROIs_vector[i])
-                mask[i, :] = abs_z > thresh_param
+            for i in np.arange(eig_vec.shape[1]):
+                abs_z = np.abs(z_ROIs_vector[:, i])
+                mask[:, i] = abs_z > thresh_param
                 # event = abs_z[mask[i, :]]
                 # Deprecated but produced an interesting result
                 # if schematic and event.size != 0:

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -773,9 +773,10 @@ def threshold_by_domains(components: dict,
             for j in range(num_features):
                 centroids = ndimage.center_of_mass(labelled, 
                                                    labels = range(num_features))
+                int_centroids = [tuple(int(x) for x in y) for y in centroids]
                 event_size = np.sum(labelled, where = labelled == j)/j
                 schem_radius = np.sqrt(event_size/np.pi)
-                rr, cc = draw.disk(centroids[i], schem_radius, shape = shape)
+                rr, cc = draw.disk(int_centroids[i], schem_radius, shape = shape)
                 event_schematics[rr, cc] = 255
                 mask.T[i] = event_schematics.flat
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -304,7 +304,10 @@ def rebuild(components: dict,
             t_start: int = None,
             t_stop: int = None,
             apply_mean_filter: bool = True,
+            mlow: float = 0.5,
+            mhigh: float = 1.0,
             apply_component_filter: bool = False,
+            chigh: float = 1.0,
             apply_masked_mean: bool = False,
             filter_method: str = 'wavelet',
             fps: float = 7.5,
@@ -394,7 +397,7 @@ def rebuild(components: dict,
         timecourses = eig_mix.T
         lpf_timecourses = np.zeros_like(timecourses)
         for index in range(timecourses.shape[0]):
-            lpf_timecourses[index] = butterworth(timecourses[index], high=0.5)
+            lpf_timecourses[index] = butterworth(timecourses[index], high=chigh)
         eig_mix = lpf_timecourses.T
 
     if (t_start == None):
@@ -425,7 +428,7 @@ def rebuild(components: dict,
         if apply_mean_filter:
             combined_mask = np.any(masks[:, reconstruct_indices], axis=1)
             mean_to_add = np.zeros_like(data_r)
-            mean_filtered = filter_mean(mean, filter_method, fps=fps)
+            mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
             mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
             data_r += mean_to_add
 
@@ -439,7 +442,7 @@ def rebuild(components: dict,
     else:
         # Run original readdition of mean
         if apply_mean_filter:
-            mean_filtered = filter_mean(mean, filter_method, fps=fps)
+            mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
             data_r += mean_filtered[t_start:t_stop, None]
 
         else:

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -710,10 +710,12 @@ def threshold_by_domains(components: dict,
             std_ROIs_vector = np.nanstd(eig_vec, axis=0)
             z_ROIs_vector = (eig_vec - mean_ROIs_vector)/std_ROIs_vector
             for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = np.abs(z_ROIs_vector[i]) > thresh_param
+                abs_z = np.abs(z_ROIs_vector[i])
+                mask[i, :] = abs_z > thresh_param
                 if schematic:
-                    schem_thresh = np.percentile(np.abs(z_ROIs_vector[i])[mask[i,:]],75) 
-                    mask[i, :] = np.abs(z_ROIs_vector[i]) > schem_thresh
+                    abs_z = abs_z[mask[i, :]]
+                    schem_thresh = np.percentile(abs_z, 75) 
+                    mask[i, :] = abs_z > schem_thresh
         case 'percentile':
             flipped = components['flipped']
             # Flip ICs where necessary using flipped from dict

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -309,7 +309,7 @@ def rebuild(components: dict,
             apply_component_filter: bool = False,
             chigh: float = 1.0,
             apply_masked_mean: bool = False,
-            filter_method: str = 'wavelet',
+            filter_method: str = 'butterworth_highpass',
             fps: float = 7.5,
             include_noise: bool = True):
     '''
@@ -329,8 +329,20 @@ def rebuild(components: dict,
             The frame to stop rebuilding the movie at.  If none is provided, the rebuilt movie ends at the last frame
         apply_mean_filter:
             Whether to apply a filter to the mean signal.
-        filter_method:;
-            The filter method to apply (see filter_mean function).
+        mlow:
+            A float determining the highpass cutoff for the mean filter, if used.
+        mhigh:
+            A float determining the lowpass cutoff for the mean filter, if used.
+        apply_component_filter:
+            Whether to apply a butterworth_lowpass filter to IC timecourses before rebuild.
+        chigh:
+            A float determining the lowpass cutoff for the component filter, if used.
+        apply_masked_mean:
+            If True, only re-adds the mean signal to pixels where at least one IC is defined. To be used for thresholded ICs.
+        filter_method:
+            The filter method to apply to the mean. Choose from 'butterworth_bandpass', 'butterworth_lowpass', 'butterworth_highpass', or 'constant'. Behaviour for 'wavelet' as yet undefined.
+        fps:
+            A float determining the fps for the source video.
         include_noise:
             Whether to include noise components when rebuilding.  If noise_components should not be included in the rebuilt movie, set this to False
 
@@ -389,11 +401,10 @@ def rebuild(components: dict,
         assert eig_vec[:,0].size == maskind[0].size, \
         "Eigenvector size is not compatible with the masked region's size"
 
-    eig_mix = components['eig_mix']
-
     # Filter component timecourses
     if apply_component_filter:
         print('Filtering component timecourses using butterworth_lowpass at 0.5Hz...')
+        eig_mix = components['eig_mix']
         timecourses = eig_mix.T
         lpf_timecourses = np.zeros_like(timecourses)
         for index in range(timecourses.shape[0]):

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -127,11 +127,14 @@ def project(vector: np.ndarray,
         try:
             u, ev, _ = linalg.svd(vector, full_matrices=False)
         except ValueError:
-            # LAPACK error if matricies are too big
-            u, ev, _ = linalg.svd(vector,
-                                  full_matrices=False,
-                                  lapack_driver='gesvd')
-
+            try:
+                # LAPACK error if matricies are too big
+                u, ev, _ = linalg.svd(vector,
+                                      full_matrices=False,
+                                      lapack_driver='gesvd')
+            except ValueError:
+                u, ev, _ = np.linalg.svd(vector,
+                                         full_matrices=False)
         components['svd_eigval'] = ev
 
         #Get starting point for decomposition based on svd mutliplier * the approximate

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -484,7 +484,7 @@ def rebuild(components: dict,
 
     if binary_threshold:
         data_binary = np.zeros(data_r)
-        data_binary(data_r > 0) = 255
+        data_binary[data_r > 0] = 255
         data_r = data_binary
 
     print('Done!')

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -424,7 +424,7 @@ def rebuild(components: dict,
             combined_mask = np.any(masks[:, reconstruct_indices], axis=1)
             mean_to_add = np.zeros_like(data_r)
             mean_filtered = None
-            mean_to_add[:, combined_mask] = mean[t_start:t_stop]
+            mean_to_add[:, combined_mask] = mean[t_start:t_stop, None]
             data_r += mean_to_add
     else:
         # Run original readdition of mean

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -716,6 +716,7 @@ def threshold_by_domains(components: dict,
         # eig_vec = eig_vec[:, signal_indices] # Don't change number of ICs, we're updating back to dict
     
     mask = np.zeros_like(eig_vec, dtype = bool)
+    print(f'eig_vec shape is: {eig_vec.shape}')
 
     match thresh_type:
         case 'max':
@@ -746,8 +747,9 @@ def threshold_by_domains(components: dict,
                 mask[i, :] = flipped_threshold_vec[i] > cutoff_vector[i]
         case 'max_value':
             max_ROIs_vector = np.max(eig_vec, axis=0)
+            print(f'max_ROIs_vector shape is: {max_ROIs_vector.shape}')
             for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = eig_vec[i] >= max_ROIs_vector[i]
+                mask[i, :] = eig_vec[i, :] >= max_ROIs_vector[i]
         case _:
             print("Threshold type is neither max nor percentile.")
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -346,7 +346,6 @@ def rebuild(components: dict,
     roimask = components['roimask']
     shape = components['shape']
     mean = components['mean']
-    masks = components['masks']
     n_components = components['n_components']
     dtype = np.float32
 
@@ -419,6 +418,7 @@ def rebuild(components: dict,
                     eig_mix[t_start:t_stop, reconstruct_indices].T).T
 
     if apply_masked_mean:
+        masks = components['masks']
         assert masks is not None, \
         "Masks have not been assigned to dictionary"
         # Apply mean to masks only, zeroing unmasked pixels

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -358,6 +358,7 @@ def rebuild(components: dict,
     assert type(components) is dict, 'Components were not in format expected'
 
     eig_vec = components['eig_vec']
+    eig_mix = components['eig_mix']
     roimask = components['roimask']
     shape = components['shape']
     mean = components['mean']
@@ -404,7 +405,6 @@ def rebuild(components: dict,
     # Filter component timecourses
     if apply_component_filter:
         print('Filtering component timecourses using butterworth_lowpass at 0.5Hz...')
-        eig_mix = components['eig_mix']
         timecourses = eig_mix.T
         lpf_timecourses = np.zeros_like(timecourses)
         for index in range(timecourses.shape[0]):

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -780,7 +780,7 @@ def threshold_by_domains(components: dict,
                                                    index = j)
                 int_centroids = [tuple(int(x) for x in y) for y in centroids]
                 event_size = np.sum(labelled, where = labelled == j)/j
-                schem_radius = np.sqrt(event_size/np.pi)
+                schem_radius = int(np.sqrt(event_size/np.pi))
                 rr, cc = draw.disk(int_centroids[i], schem_radius, shape = shape)
                 event_schematics[rr, cc] = 255
                 mask.T[i] = event_schematics.flat

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -747,7 +747,7 @@ def threshold_by_domains(components: dict,
         case 'max_value':
             max_ROIs_vector = np.max(eig_vec, axis=0)
             for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = eig_vec >= max_ROIs_vector
+                mask[i, :] = eig_vec[i] >= max_ROIs_vector[i]
         case _:
             print("Threshold type is neither max nor percentile.")
 

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -712,7 +712,7 @@ def threshold_by_domains(components: dict,
             for i in np.arange(eig_vec.shape[0]):
                 abs_z = np.abs(z_ROIs_vector[i])
                 mask[i, :] = abs_z > thresh_param
-                if schematic:
+                if schematic and abs_z.size != 0:
                     event = abs_z[mask[i, :]]
                     schem_thresh = np.percentile(event, 75) 
                     mask[i, :] = abs_z > schem_thresh

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -763,18 +763,21 @@ def threshold_by_domains(components: dict,
 
     if schematic:
         event_schematics = np.zeros(shape, dtype=np.uint8)
+        eigenmask = np.zeros(shape, dtype=bool)
         eigenbrain = np.empty(shape)
         eigenbrain[:] = np.nan
 
         for i in range(mask.shape[1]):
-            eigenbrain.flat[maskind] = mask.T[i]
-            labelled, num_features = ndimage.label(eigenbrain, 
+            eigenmask.flat[maskind] = mask.T[i]
+            eigenbrain.flat[maskind] = eig_vec.T[i]
+            labelled, num_features = ndimage.label(eigenmask, 
                                                     structure = [[0,1,0],
                                                                  [1,1,1],
                                                                  [0,1,0]])
             for j in range(num_features):
-                centroids = ndimage.center_of_mass(labelled, 
-                                                   labels = range(num_features))
+                centroids = ndimage.center_of_mass(eigenbrain, 
+                                                   labels = labelled,
+                                                   index = j)
                 int_centroids = [tuple(int(x) for x in y) for y in centroids]
                 event_size = np.sum(labelled, where = labelled == j)/j
                 schem_radius = np.sqrt(event_size/np.pi)

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -451,13 +451,13 @@ def rebuild(components: dict,
     print('\nReconstructing....')
     data_r = np.dot(eig_vec[:, reconstruct_indices],
                     eig_mix[t_start:t_stop, reconstruct_indices].T).T
-    spatiotemporal_event_masks = data_r[data_r > 0]
+    # spatiotemporal_event_masks = data_r[data_r > 0]
 
     if apply_masked_mean:
         # Apply mean to masks only, zeroing unmasked pixels
-        # spatiotemporal_event_masks = np.zeros_like(data_r)
-        # spatiotemporal_event_masks[data_r > 0] = 255
-        # spatiotemporal_event_masks = spatiotemporal_event_masks.astype(bool)
+        spatiotemporal_event_masks = np.zeros_like(data_r)
+        spatiotemporal_event_masks[data_r > 0] = 255
+        spatiotemporal_event_masks = spatiotemporal_event_masks.astype(bool)
         masks = components['thresh_masks']
         assert masks is not None, \
         "Masks have not been assigned to dictionary"

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -713,7 +713,7 @@ def rebuild_eigenbrain(eig_vec: np.ndarray,
         else:
             eigenbrains = np.empty(
                 (roimask.shape[0], roimask.shape[1], eig_vec.shape[1]))
-            eigenbrains[:] = np.NAN
+            eigenbrains[:] = np.nan
             eigenbrains[x, y, :] = eig_vec
         eigenbrains = np.swapaxes(eigenbrains, 0, 2)
         eigenbrains = np.swapaxes(eigenbrains, 1, 2)
@@ -730,7 +730,7 @@ def rebuild_eigenbrain(eig_vec: np.ndarray,
             eigenbrain = eigenbrain.reshape(eigb_shape)
         else:
             eigenbrain = np.empty(roimask.shape)
-            eigenbrain[:] = np.NAN
+            eigenbrain[:] = np.nan
             eigenbrain.flat[maskind] = eig_vec.T[index]
 
         return eigenbrain

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -763,9 +763,11 @@ def threshold_by_domains(components: dict,
 
     if schematic:
         event_schematics = np.zeros(shape, dtype=np.uint8)
+        eigenbrain = np.empty(shape)
+        eigenbrain[:] = np.nan
 
         for i in range(mask.shape[1]):
-            event_schematics.flat[maskind] = mask.T[i]
+            eigenbrain.flat[maskind] = mask.T[i]
             labelled, num_features = ndimage.label(eigenbrain, 
                                                     structure = [[0,1,0],
                                                                  [1,1,1],

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -465,7 +465,7 @@ def rebuild(components: dict,
             mean_to_add = np.zeros_like(data_r)
             mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
             mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
-            data_r += mean_to_add[spatiotemporal_event_masks]
+            data_r[spatiotemporal_event_masks] += mean_to_add
 
         else:
             print('Not filtering mean')
@@ -473,7 +473,7 @@ def rebuild(components: dict,
             mean_to_add = np.zeros_like(data_r)
             mean_filtered = None
             mean_to_add[:, combined_mask] = mean[t_start:t_stop, None]
-            data_r += mean_to_add[spatiotemporal_event_masks]
+            data_r[spatiotemporal_event_masks] += mean_to_add
     else:
         # Run original readdition of mean
         if apply_mean_filter:

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -264,6 +264,7 @@ def project(vector: np.ndarray,
         try:
             vector = vector.astype('float64')
             rebuilt = rebuild(components,
+                              artifact_components='none',
                               apply_mean_filter=False).T
 
             rebuilt -= rebuilt.mean(axis=0)

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -403,13 +403,9 @@ def rebuild(components: dict,
 
     # Filter component timecourses
     if apply_component_filter:
-        print('Filtering component timecourses using butterworth_lowpass at 0.5Hz...')
         eig_mix = components['eig_mix']
-        timecourses = eig_mix.T
-        lpf_timecourses = np.zeros_like(timecourses)
-        for index in range(timecourses.shape[0]):
-            lpf_timecourses[index] = butterworth(timecourses[index], high=chigh)
-        eig_mix = lpf_timecourses.T
+        lpf_eig_mix = filter_components(eig_mix, fps=fps, high_cutoff=chigh)
+        eig_mix = lpf_eig_mix
 
     if (t_start == None):
         t_start = 0
@@ -565,6 +561,34 @@ def filter_mean(mean: np.ndarray,
          + "' not supported!\n\t Supported methods: butterworth, butterworth_bandpass, wavelet")
 
     return mean_filtered
+
+
+def filter_components(eig_mix: np.ndarray,
+                      fps: float = 7.5,
+                      high_cutoff: float = 0.5):
+    '''
+    Applies a butterworth low pass filter to the ica component timecourses.
+
+    Arguments:
+        eig_mix: 
+            The mixing matrix containing IC timecourses.
+        fps:
+            Sampling rate of the video.
+        high_cutoff:
+            The frequency cutoff to apply the low pass filter at.
+
+    Returns:
+        lpf_eig_mix: The filtered IC timecourses reconstructed as the eig_mix matrix.
+    '''
+    print('Filtering component timecourses using butterworth_lowpass at '+ high_cutoff +'Hz...')
+
+    timecourses = eig_mix.T
+    lpf_timecourses = np.zeros_like(timecourses)
+    for index in range(timecourses.shape[0]):
+        lpf_timecourses[index] = butterworth(timecourses[index], fps=fps, high=high_cutoff)
+    lpf_eig_mix = lpf_timecourses.T
+
+    return lpf_eig_mix
 
 
 def rebuild_mean_roi_timecourse(components: np.ndarray,

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -451,11 +451,11 @@ def rebuild(components: dict,
     print('\nReconstructing....')
     data_r = np.dot(eig_vec[:, reconstruct_indices],
                     eig_mix[t_start:t_stop, reconstruct_indices].T).T
-    
-    spatiotemporal_event_masks = np.bool(data_r)
-    spatiotemporal_event_masks[data_r > 0] = True
 
     if apply_masked_mean:
+        spatiotemporal_event_masks = np.zeros_like(data_r)
+        spatiotemporal_event_masks[data_r > 0] = 255
+        spatiotemporal_event_masks = spatiotemporal_event_masks.astype(bool)
         masks = components['thresh_masks']
         assert masks is not None, \
         "Masks have not been assigned to dictionary"

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -264,8 +264,7 @@ def project(vector: np.ndarray,
         try:
             vector = vector.astype('float64')
             rebuilt = rebuild(components,
-                              artifact_components='none',
-                              vector=True).T
+                              apply_mean_filter=False).T
 
             rebuilt -= rebuilt.mean(axis=0)
             vector -= vector.mean(axis=0)

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -641,7 +641,8 @@ def threshold_by_domains(components: dict,
                    blur: int = 1,
                    min_mask_size: int = 64,
                    thresh_type: str = 'max',
-                   thresh_param: float = None):
+                   thresh_param: float = None,
+                   schematic: bool = False):
     '''
     Function based on modified get_domain_map(). Thresholds ICs using a variety of methods for selective rebuild.
 
@@ -710,6 +711,9 @@ def threshold_by_domains(components: dict,
             z_ROIs_vector = (eig_vec - mean_ROIs_vector)/std_ROIs_vector
             for i in np.arange(eig_vec.shape[0]):
                 mask[i, :] = np.abs(z_ROIs_vector[i]) > thresh_param
+                if schematic:
+                    schem_thresh = np.percentile(np.abs(z_ROIs_vector[i])[mask[i,:]],75) 
+                    mask[i, :] = np.abs(z_ROIs_vector[i]) > schem_thresh
         case 'percentile':
             flipped = components['flipped']
             # Flip ICs where necessary using flipped from dict

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -429,7 +429,7 @@ def rebuild(components: dict,
                     eig_mix[t_start:t_stop, reconstruct_indices].T).T
 
     if apply_masked_mean:
-        masks = components['masks']
+        masks = components['thresh_masks']
         assert masks is not None, \
         "Masks have not been assigned to dictionary"
         # Apply mean to masks only, zeroing unmasked pixels

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -580,7 +580,7 @@ def filter_components(eig_mix: np.ndarray,
     Returns:
         lpf_eig_mix: The filtered IC timecourses reconstructed as the eig_mix matrix.
     '''
-    print('Filtering component timecourses using butterworth_lowpass at '+ high_cutoff +'Hz...')
+    print('Filtering component timecourses using butterworth_lowpass at '+ str(high_cutoff) +'Hz...')
 
     timecourses = eig_mix.T
     lpf_timecourses = np.zeros_like(timecourses)

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -543,6 +543,12 @@ def filter_mean(mean: np.ndarray,
         wavelet = waveletAnalysis(mean.astype('float64'), fps=fps)
         mean_filtered = wavelet.noiseFilter(upperPeriod=1 / low_cutoff)
 
+    elif filter_method == 'constant':
+        mean_template = np.zeros_like(mean)
+        meanest_mean = np.mean(mean)
+        mean_filtered = mean_template + meanest_mean
+        print('Mean set as constant: dfof = ' + str(meanest_mean))
+
     else:
         raise Exception("Filter method '" + str(filter_method)\
          + "' not supported!\n\t Supported methods: butterworth, butterworth_bandpass, wavelet")

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1519,7 +1519,7 @@ def dynamic_threshold(components: dict) -> dict:
     # Good to check our flipped values remain consistent vs other calculations
     if 'flipped' in components.keys():
         print("flipped already exists in components dict.")
-        assert flipped == components['flipped']
+        assert np.all(flipped == components['flipped'])
     else:
         output['flipped'] = flipped
     output['component_thresholds'] = thresholds
@@ -1543,8 +1543,8 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
 
         # We calculate the peaks and bounds of each timecourse distribution
         peak = (bins[k] + bins[k + 1]) / 2
-        min = np.min(bins)
-        max = np.max(bins)
+        min = np.min(timecourses[i])
+        max = np.max(timecourses[i])
         assert np.all(max > 0), "Timecourse {i} distribution is deviant, max is less than 0."
         assert np.all(min < 0), "Timecourse {i} distribution is deviant, min is greater than 0."
         
@@ -1553,7 +1553,7 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
             short_tail = max
         else:
             short_tail = min
-        # We work in normalised polarity now for clarity
+        # We work in normalised polarity now for clarity (assume short tail negative)
         flip = -1 * np.sign(short_tail)
         timecourse = flip * timecourses[i].copy()
         noise_mean = flip * peak
@@ -1573,9 +1573,14 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
     # Good to check our flipped values remain consistent vs any previous 
     # calculations from other methods.
     if 'flipped' in components.keys():
+        non_artifact_indices = np.where(components['artifact_components'] == False)
+        non_noise_indices = np.where(components['noise_components'] == False)
+        signal_indices = np.intersect1d(non_artifact_indices, non_noise_indices)
         print("flipped already exists in components dict.")
-        assert flipped == components['flipped']
+        assert np.all(flipped == components['flipped'])
     else:
         output['flipped'] = flipped
+    
+    output['flipped'] = flipped
     output['timecourse_thresholds'] = thresholds
     return output

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1493,3 +1493,15 @@ def filter_comparison(components: dict,
          resize_factor=1 / 2,
          save_cbar=True,
          overlay=overlay)
+
+def dynamic_threshold(components: dict) -> dict:
+    eig_vec = components['eig_vec']
+    output = {}
+    min = np.min(eig_vec, axis=0)
+    max = np.max(eig_vec, axis=0)
+    assert max > 0, "eig_vec distribution is deviant, max is less than 0."
+    assert min < 0, "eig_vec distribution is deviant, min is greater than 0."
+    output['flipped'] = np.where(np.abs(min) > max, 1, -1)
+    output['threshold'] = np.where(np.abs(min) > max, max, min)
+
+    return output

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1495,13 +1495,84 @@ def filter_comparison(components: dict,
          overlay=overlay)
 
 def dynamic_threshold(components: dict) -> dict:
+    # Returns a pySEAS-compatible dictionary entry for the threshold values as
+    # calculated per "Dynamic Threshold" method in Weiser et al. 2023. These
+    # thresholds are recorded in the polarity relative to the original ICA
+    # results (ie; not flipped). 
+
     eig_vec = components['eig_vec']
     output = {}
-    min = np.min(eig_vec, axis=0)
-    max = np.max(eig_vec, axis=0)
-    assert max > 0, "eig_vec distribution is deviant, max is less than 0."
-    assert min < 0, "eig_vec distribution is deviant, min is greater than 0."
-    output['flipped'] = np.where(np.abs(min) > max, 1, -1)
-    output['threshold'] = np.where(np.abs(min) > max, max, min)
+    
+    # We calculate the bounds of the eig_vec distribution
+    min = np.min(eig_vec, axis = 0)
+    max = np.max(eig_vec, axis = 0)
 
+    # And check the distribution is centred around zero
+    assert np.all(max > 0), "eig_vec distribution is deviant, max is less than 0."
+    assert np.all(min < 0), "eig_vec distribution is deviant, min is greater than 0."
+    
+    # Then we identify return short tail as threshold, adjusting for flipping by ICA
+    short_tail = np.where(np.abs(min) > max, max, min)
+    flipped = -1 * np.sign(short_tail)
+    thresholds = flipped * short_tail
+
+    # Good to check our flipped values remain consistent vs other calculations
+    if 'flipped' in components.keys():
+        assert flipped == components['flipped']
+    else:
+        output['flipped'] = flipped
+    output['component_thresholds'] = thresholds
+    return output
+
+def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
+    # Returns a pySEAS-compatible dictionary entry for the threshold values as
+    # calculated per "Estimating binary neural activity" method in
+    # Suarez et al. 2023. These thresholds are recorded in the polarity 
+    # relative to the original ICA results (ie; not flipped).
+
+    timecourses = components['eig_vec'].T
+    n_components = timecourses.shape[0]
+    output = {}
+    
+    flipped = []
+    thresholds = []
+    for i in range(n_components):
+        counts, bins = np.histogram(timecourses[i], bins = 'fd')
+        k = np.argmax(counts)
+
+        # We calculate the peaks and bounds of each timecourse distribution
+        peak = (bins[k] + bins[k + 1]) / 2
+        min = np.min(bins)
+        max = np.max(bins)
+        assert np.all(max > 0), "Timecourse {i} distribution is deviant, max is less than 0."
+        assert np.all(min < 0), "Timecourse {i} distribution is deviant, min is greater than 0."
+        
+        # And check the polarity of the distribution as returned by ICA
+        if np.abs(min) > max:
+            short_tail = max
+        else:
+            short_tail = min
+
+        # We work in normalised polarity for now for clarity
+        flip = -1 * np.sign(short_tail)
+        timecourse = flip * timecourses[i].copy()
+        noise_mean = flip * peak
+
+        # And calculate the noise std by extrapolating the short tail.
+        noise_deltas = np.where(timecourse < noise_mean, 
+                                noise_mean - timecourses[i], 
+                                np.nan)
+        noise_deltas = noise_deltas(~np.isnan(noise_deltas))
+        noise_distr = np.concat(noise_deltas, -1 * noise_deltas)
+        noise_std = np.std(noise_distr)
+        
+        flipped[i] = flip
+        thresholds[i] = flip * (noise_mean + thresh * noise_std)
+    
+    # Good to check our flipped values remain consistent vs other calculations
+    if 'flipped' in components.keys():
+        assert flipped == components['flipped']
+    else:
+        output['flipped'] = flipped
+    output['timecourse_thresholds'] = thresholds
     return output

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -719,6 +719,214 @@ def rebuild_split_components(components: dict,
         #data_r[data_r > 0] = 255
         tif.imwrite('/QRISdata/Q5451/temp/tests/pyseas_split_components/' + comp_out, data_r,compression='lzw', imagej=True)
             
+def rebuild_split_clusters(components: dict,
+            artifact_components: np.ndarray = None,
+            t_start: int = None,
+            t_stop: int = None,
+            apply_mean_filter: bool = True,
+            mlow: float = 0.5,
+            mhigh: float = 1.0,
+            apply_component_filter: bool = False,
+            chigh: float = 1.0,
+            apply_component_threshold: bool = False,
+            cthresh: float = 2.0,
+            apply_masked_mean: bool = False,
+            binary_threshold: bool = False,
+            filter_method: str = 'butterworth_highpass',
+            fps: float = 7.5,
+            include_noise: bool = True):
+    '''
+    Rebuild original vector space based on a subset of principal 
+    components of the data.  Eigenvectors to use are specified where 
+    artifact_components == False.  Returns a matrix data_r, the reconstructed 
+    vector projected back into its original dimensions.
+
+    Arguments:
+        components: 
+            The components from ica_project.  artifact_components must be assigned to components before rebuilding, or passed in explicitly
+        artifact_components:
+            Overrides the artifact_components key in components, to rebuild all components except those specified
+        t_start: 
+            The frame to start rebuilding the movie at.  If none is provided, the rebuilt movie starts at the first frame
+        t_stop: 
+            The frame to stop rebuilding the movie at.  If none is provided, the rebuilt movie ends at the last frame
+        apply_mean_filter:
+            Whether to apply a filter to the mean signal.
+        mlow:
+            A float determining the highpass cutoff for the mean filter, if used.
+        mhigh:
+            A float determining the lowpass cutoff for the mean filter, if used.
+        apply_component_filter:
+            Whether to apply a butterworth_lowpass filter to IC timecourses before rebuild.
+        chigh:
+            A float determining the lowpass cutoff for the component filter, if used.
+        apply_component_threshold:
+            Whether to apply a z-score threshold on the component timeseries.
+        cthresh:
+            A float determining the z-score threshold for the component threshold, if used.
+        apply_masked_mean:
+            If True, only re-adds the mean signal to pixels where at least one IC is defined. To be used for thresholded ICs.
+        filter_method:
+            The filter method to apply to the mean. Choose from 'butterworth_bandpass', 'butterworth_lowpass', 'butterworth_highpass', or 'constant'. Behaviour for 'wavelet' as yet undefined.
+        fps:
+            A float determining the fps for the source video.
+        include_noise:
+            Whether to include noise components when rebuilding.  If noise_components should not be included in the rebuilt movie, set this to False
+
+    Returns:
+        data_r: The ICA filtered video.
+    '''
+    print('\nRebuilding Data from Selected ICs\n-----------------------')
+
+    if type(components) is str:
+        f = hdf5manager(components)
+        components = f.load()
+
+    assert type(components) is dict, 'Components were not in format expected'
+
+    eig_vec = components['eig_vec']
+    eig_mix = components['eig_mix']
+    roimask = components['roimask']
+    shape = components['shape']
+    mean = components['mean']
+    n_components = components['n_components']
+    dtype = np.float32
+
+    t, x, y = shape
+    l = eig_vec[:, 0].size
+
+    if mean.ndim > 1:  # why is there sometimes an extra dimension added?
+        mean = mean.flatten()
+
+    if artifact_components is None:
+        artifact_components = components['artifact_components']
+    elif artifact_components == 'none':
+        print('including all components')
+        artifact_components = np.zeros(n_components)
+    
+    if ((not include_noise) and ('noise_components' in components.keys())):
+        print('Not rebuilding noise components')
+        artifact_components += components['noise_components']
+        artifact_components[np.where(artifact_components > 1)] = 1
+
+    reconstruct_indices = np.where(artifact_components == 0)[0]
+
+    if reconstruct_indices.size == 0:
+        print('No indices were selected for reconstruction.')
+        print('Returning empty matrix...')
+        data_r = np.zeros((t, x, y), dtype='uint8')
+        data_r = data_r[t_start:t_stop]
+        return data_r
+
+    n_components = reconstruct_indices.size
+
+    # Make sure vector extracted properly matches the roimask given.
+    if roimask is None:
+        assert eig_vec[:, 0].size == x * y, (
+            "Eigenvector size isn't compatible with the shape of the output "
+            'matrix')
+    else:
+        maskind = np.where(roimask.flat == 1)
+        assert eig_vec[:,0].size == maskind[0].size, \
+        "Eigenvector size is not compatible with the masked region's size"
+
+    # Filter component timecourses
+    if apply_component_filter:
+        lpf_eig_mix = filter_components(eig_mix, fps=fps, high_cutoff=chigh)
+        eig_mix = lpf_eig_mix
+
+    # Threshold component timecourses
+    if apply_component_threshold:
+        thresh_eig_mix = threshold_components(eig_mix, thresh_param=cthresh)
+        eig_mix = thresh_eig_mix
+
+    if (t_start == None):
+        t_start = 0
+
+    if (t_stop == None):
+        t_stop = eig_mix.shape[0]
+
+    if (t_stop - t_start) is not shape[0]:
+        shape = (t_stop - t_start, shape[1], shape[2])
+
+    t = t_stop - t_start
+
+    print('\nRebuilding ICA...')
+    print('number of elements included:', n_components)
+    print('eig_vec:', eig_vec.shape)
+    print('eig_mix:', eig_mix.shape)
+
+    print('\nReconstructing....')
+    clusters = components['component_clusters']
+    for i in range(1,np.max(clusters)):
+        print(f'Reuilding cluster: {i}')
+        cluster_indices = np.where(clusters == i)[0]
+        signal_indices = np.where(artifact_components == 0)[0]
+        reconstruct_indices = np.intersect1d(cluster_indices, signal_indices)
+        data_r = np.dot(eig_vec[:, reconstruct_indices],
+                        eig_mix[t_start:t_stop, reconstruct_indices].T).T
+        # spatiotemporal_event_masks = data_r[data_r > 0]
+
+        if apply_masked_mean:
+            # Apply mean to masks only, zeroing unmasked pixels
+            spatiotemporal_event_masks = np.zeros_like(data_r)
+            spatiotemporal_event_masks[data_r > 0] = 255
+            spatiotemporal_event_masks = spatiotemporal_event_masks.astype(bool)
+            masks = components['thresh_masks']
+            assert masks is not None, \
+            "Masks have not been assigned to dictionary"
+            if apply_mean_filter:
+                combined_mask = np.any(masks[:, reconstruct_indices], axis=1)
+                mean_to_add = np.zeros_like(data_r)
+                mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
+                mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
+                data_r += mean_to_add
+                data_r[~spatiotemporal_event_masks] = 0
+
+            else:
+                print('Not filtering mean')
+                combined_mask = np.any(masks[:, reconstruct_indices], axis=1)
+                mean_to_add = np.zeros_like(data_r)
+                mean_filtered = None
+                mean_to_add[:, combined_mask] = mean[t_start:t_stop, None]
+                data_r += mean_to_add
+                data_r[~spatiotemporal_event_masks] = 0
+        else:
+            # Run original readdition of mean
+            if apply_mean_filter:
+                mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
+                data_r += mean_filtered[t_start:t_stop, None]
+
+            else:
+                print('Not filtering mean')
+                mean_filtered = None
+                data_r += mean[t_start:t_stop, None]
+
+        if binary_threshold:
+            data_binary = np.zeros(data_r)
+            data_binary[data_r > 0] = 255
+            data_r = data_binary
+
+        print('Done!')
+
+        if roimask is None:
+            data_r = data_r.reshape(shape)
+        else:
+            reconstructed = np.zeros((x * y, t), dtype=dtype)
+            print(f'data_r shape is: {data_r.shape}')
+            print(f'reconstructed shape is: {reconstructed.shape}')
+            print(f'maskind is: {maskind}')
+            reconstructed[maskind] = data_r.swapaxes(0, 1)
+            reconstructed = reconstructed.swapaxes(0, 1)
+            data_r = reconstructed.reshape(t, x, y)
+        comp_out = 'sub-116_rec-baseline_run-01_cluster-' + str(i) + '.tif'
+        data_r[data_r < 0.0] = 0.0
+        data_r = data_r*255
+        data_r[data_r > 255.0] = 255.0
+        data_r = data_r.astype(np.uint8)
+        #data_r[data_r > 0] = 255
+        print("Writing data to tiff...")
+        tif.imwrite('C:/Users/aluff/Git_Clones/test_data/' + comp_out, data_r,compression='lzw', imagej=True)
 
 def approximate_svd_linearity_transition(eig_val: np.ndarray):
     '''

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1172,6 +1172,25 @@ def threshold_by_domains(components: dict,
             print(f'max_ROIs_vector shape is: {max_ROIs_vector.shape}')
             for i in np.arange(eig_vec.shape[1]):
                 mask[:, i] = eig_vec[:, i] >= max_ROIs_vector[i]
+        case 'dynamic':
+            # We calculate the bounds of the eig_vec distribution
+            min = np.min(eig_vec, axis = 0)
+            max = np.max(eig_vec, axis = 0)
+
+            # And check the distribution is centred around zero
+            assert np.all(max > 0), "eig_vec distribution is deviant, max is less than 0."
+            assert np.all(min < 0), "eig_vec distribution is deviant, min is greater than 0."
+            
+            # Then we identify return short tail as threshold, adjusting for flipping by ICA
+            short_tail = np.where(np.abs(min) > max, max, min)
+            flipped = -1 * np.sign(short_tail)
+            thresholds = -1 * short_tail
+            
+            flipped_vec = np.multiply(flipped, eig_vec)
+            flipped_thresholds = np.multiply(flipped, thresholds)
+
+            for i in np.arange(eig_vec.shape[0]):
+                mask[i, :] = flipped_vec[i] > flipped_thresholds[i]
         case _:
             print("Threshold type is neither max nor percentile.")
 
@@ -1583,4 +1602,55 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
     
     #output['flipped'] = flipped
     output['timecourse_thresholds'] = thresholds
+    return output
+
+def rebuilt_noise_SD_threshold(components: dict, thresh: float = 2) -> dict:
+    # Returns a pySEAS-compatible dictionary entry for the threshold values as
+    # calculated per "Dynamic Threshold" method in Weiser et al. 2023, but
+    # applied to rebuilt timecourses (+ original frame-wise mean). These
+    # thresholds are recorded in the polarity of the original signal (ie;
+    # all positive). 
+
+    eig_vec = components['eig_vec']
+    timecourses = components['eig_mix'].T
+    frame_mean = components['mean']
+    n_components = timecourses.shape[0]
+    output = {}
+    
+    thresholds = np.zeros(n_components)
+    binary_timecourses = np.zeros_like(timecourses, dtype = np.int8)
+    # We calculate the max of eig_vec distribution and rebuild our timecourses
+    max_weights = np.max(eig_vec, axis = 0)
+    rebuilt_timecourses = max_weights[:, np.newaxis] * timecourses + frame_mean
+    
+    for i in range(n_components):
+        timecourse = rebuilt_timecourses[i]
+        counts, bins = np.histogram(timecourse, bins = 'fd')
+        k = np.argmax(counts)
+
+        # We calculate the peaks and bounds of each timecourse distribution
+        noise_mean = (bins[k] + bins[k + 1]) / 2
+        min = np.min(timecourse)
+        max = np.max(timecourse)
+        assert np.all(max > 0), \
+            "Timecourse index={i} distribution is deviant, max is less than 0."
+        assert np.all(min < noise_mean), \
+            "Timecourse index={i} distribution is deviant, min >= noise peak."
+        
+        # We work in normalised polarity because timecourse has been rebuilt
+        # and calculate the noise std by extrapolating the one-sided
+        # distribution below the noise mean.
+        noise_deltas = np.where(timecourse < noise_mean, 
+                                noise_mean - timecourse, 
+                                np.nan)
+        noise_deltas = noise_deltas[~np.isnan(noise_deltas)]
+        noise_distr = np.concatenate((noise_deltas, -1 * noise_deltas))
+        noise_std = np.std(noise_distr)
+        
+        threshold = noise_mean + thresh * noise_std
+        binary_timecourses[i] = np.where(timecourse >= threshold)
+        timecourse[timecourse >= thresholds[i]]
+
+    output['rebuilt_timecourse_thresholds'] = thresholds
+    output['binary_threshold_timecourses'] = binary_timecourses.T
     return output

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1514,10 +1514,11 @@ def dynamic_threshold(components: dict) -> dict:
     # Then we identify return short tail as threshold, adjusting for flipping by ICA
     short_tail = np.where(np.abs(min) > max, max, min)
     flipped = -1 * np.sign(short_tail)
-    thresholds = flipped * short_tail
+    thresholds = short_tail
 
     # Good to check our flipped values remain consistent vs other calculations
     if 'flipped' in components.keys():
+        print("flipped already exists in components dict.")
         assert flipped == components['flipped']
     else:
         output['flipped'] = flipped
@@ -1530,12 +1531,12 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
     # Suarez et al. 2023. These thresholds are recorded in the polarity 
     # relative to the original ICA results (ie; not flipped).
 
-    timecourses = components['eig_vec'].T
+    timecourses = components['eig_mix'].T
     n_components = timecourses.shape[0]
     output = {}
     
-    flipped = []
-    thresholds = []
+    flipped = np.ones(n_components)
+    thresholds = np.zeros(n_components)
     for i in range(n_components):
         counts, bins = np.histogram(timecourses[i], bins = 'fd')
         k = np.argmax(counts)
@@ -1552,25 +1553,27 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
             short_tail = max
         else:
             short_tail = min
-
-        # We work in normalised polarity for now for clarity
+        # We work in normalised polarity now for clarity
         flip = -1 * np.sign(short_tail)
         timecourse = flip * timecourses[i].copy()
         noise_mean = flip * peak
-
-        # And calculate the noise std by extrapolating the short tail.
+        # And calculate the noise std by extrapolating the short tail
         noise_deltas = np.where(timecourse < noise_mean, 
-                                noise_mean - timecourses[i], 
+                                noise_mean - timecourse, 
                                 np.nan)
-        noise_deltas = noise_deltas(~np.isnan(noise_deltas))
-        noise_distr = np.concat(noise_deltas, -1 * noise_deltas)
+        noise_deltas = noise_deltas[~np.isnan(noise_deltas)]
+        print(noise_deltas.shape)
+        noise_distr = np.concatenate((noise_deltas, -1 * noise_deltas))
         noise_std = np.std(noise_distr)
         
         flipped[i] = flip
+        # Return to original polarity to record threshold
         thresholds[i] = flip * (noise_mean + thresh * noise_std)
     
-    # Good to check our flipped values remain consistent vs other calculations
+    # Good to check our flipped values remain consistent vs any previous 
+    # calculations from other methods.
     if 'flipped' in components.keys():
+        print("flipped already exists in components dict.")
         assert flipped == components['flipped']
     else:
         output['flipped'] = flipped

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1189,8 +1189,8 @@ def threshold_by_domains(components: dict,
             flipped_vec = np.multiply(flipped, eig_vec)
             flipped_thresholds = np.multiply(flipped, thresholds)
 
-            for i in np.arange(eig_vec.shape[0]):
-                mask[i, :] = flipped_vec[i] > flipped_thresholds[i]
+            for i in np.arange(eig_vec.shape[1]):
+                mask[:, i] = flipped_vec[:, i] > flipped_thresholds[i]
         case _:
             print("Threshold type is neither max nor percentile.")
 
@@ -1648,7 +1648,7 @@ def rebuilt_noise_SD_threshold(components: dict, thresh: float = 2) -> dict:
         noise_std = np.std(noise_distr)
         
         threshold = noise_mean + thresh * noise_std
-        binary_timecourses[i] = np.where(timecourse >= threshold)
+        binary_timecourses[i] = np.where(timecourse >= threshold, 1, 0)
         timecourse[timecourse >= thresholds[i]]
 
     output['rebuilt_timecourse_thresholds'] = thresholds

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -154,6 +154,7 @@ def project(vector: np.ndarray,
                           w_init=w_init)
 
             eig_vec = ica.fit_transform(vector)
+            print("n_iter:" , ica.n_iter_)
             eig_mix = ica.mixing_
 
             noise, cutoff = sort_noise(eig_mix.T)

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -499,6 +499,9 @@ def rebuild(components: dict,
         data_r = data_r.reshape(shape)
     else:
         reconstructed = np.zeros((x * y, t), dtype=dtype)
+        print(f'data_r shape is: {data_r.shape}')
+        print(f'reconstructed shape is: {reconstructed.shape}')
+        print(f'maskind is: {maskind}')
         reconstructed[maskind] = data_r.swapaxes(0, 1)
         reconstructed = reconstructed.swapaxes(0, 1)
         data_r = reconstructed.reshape(t, x, y)
@@ -643,11 +646,15 @@ def rebuild_split_components(components: dict,
     print('eig_mix:', eig_mix.shape)
 
     print('\nReconstructing....')
-    data_c = []
-    t = 1
+    print(f'reconstruct_indices are: {reconstruct_indices}')
     for i in reconstruct_indices:
-        data_r = np.dot(eig_vec[:, i],
-                        eig_mix[t_start:t_stop, i].T).T
+        print(f'i is: {i}')
+        print(f'Selected eig_vec shape is: {eig_vec[:, i].shape}')
+        print(f'Selected eig_mix shape is: {eig_mix[t_start:t_stop, i].T.shape}')
+        #data_r = np.dot(eig_vec[:, i],
+        #                eig_mix[t_start:t_stop, i].T).T
+        data_rl = [eig_vec[:,i] * m for m in eig_mix[t_start:t_stop, i]]
+        data_r = np.stack(data_rl, axis=0)
         # spatiotemporal_event_masks = data_r[data_r > 0]
 
         if apply_masked_mean:
@@ -659,10 +666,11 @@ def rebuild_split_components(components: dict,
             assert masks is not None, \
             "Masks have not been assigned to dictionary"
             if apply_mean_filter:
-                combined_mask = np.any(masks[:, i], axis=1)
+                combined_mask = masks[:, i]
                 mean_to_add = np.zeros_like(data_r)
                 mean_filtered = filter_mean(mean, filter_method, low_cutoff=mlow, high_cutoff=mhigh, fps=fps)
-                mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
+                #mean_to_add[:, combined_mask] = mean_filtered[t_start:t_stop, None]
+                mean_to_add = 0.028687261
                 data_r += mean_to_add
                 data_r[~spatiotemporal_event_masks] = 0
 
@@ -696,12 +704,20 @@ def rebuild_split_components(components: dict,
             data_r = data_r.reshape(shape)
         else:
             reconstructed = np.zeros((x * y, t), dtype=dtype)
+            print(f'data_r shape is: {data_r.shape}')
+            print(f'reconstructed shape is: {reconstructed.shape}')
+            print(f'maskind shape: {maskind}')
             reconstructed[maskind] = data_r.swapaxes(0, 1)
             reconstructed = reconstructed.swapaxes(0, 1)
             data_r = reconstructed.reshape(t, x, y)
-            data_c.append(data_r)
-    data_r = np.stack(data_c, axis=0)
-    return data_r
+        comp_out = 'sub-071_rec-baseline_run-02_id-' + str(i) + '.tif'
+        data_r[data_r < 0.0] = 0.0
+        data_r = data_r*255
+        data_r[data_r > 255.0] = 255.0
+        data_r = data_r.astype(np.uint8)
+        #data_r[data_r > 0] = 255
+        tif.imwrite('/QRISdata/Q5451/temp/tests/pyseas_split_components/' + comp_out, data_r,compression='lzw', imagej=True)
+            
 
 def approximate_svd_linearity_transition(eig_val: np.ndarray):
     '''

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1581,6 +1581,6 @@ def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:
     else:
         output['flipped'] = flipped
     
-    output['flipped'] = flipped
+    #output['flipped'] = flipped
     output['timecourse_thresholds'] = thresholds
     return output

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1192,7 +1192,7 @@ def threshold_by_domains(components: dict,
             for i in np.arange(eig_vec.shape[1]):
                 mask[:, i] = flipped_vec[:, i] > flipped_thresholds[i]
         case _:
-            print("Threshold type is neither max nor percentile.")
+            print(f"Threshold type {thresh_type} is not recognised.")
 
     # Filter small mask ROIs and smooth using blur
     if blur:
@@ -1533,7 +1533,7 @@ def dynamic_threshold(components: dict) -> dict:
     # Then we identify return short tail as threshold, adjusting for flipping by ICA
     short_tail = np.where(np.abs(min) > max, max, min)
     flipped = -1 * np.sign(short_tail)
-    thresholds = short_tail
+    thresholds = -1 * short_tail
 
     # Good to check our flipped values remain consistent vs other calculations
     if 'flipped' in components.keys():

--- a/seas/ica.py
+++ b/seas/ica.py
@@ -1540,8 +1540,12 @@ def dynamic_threshold(components: dict) -> dict:
         print("flipped already exists in components dict.")
         assert np.all(flipped == components['flipped'])
     else:
-        output['flipped'] = flipped
+        output['flipped'] = flipped.astype(np.int8)
+
+    binary_ICs = np.where(flipped * eig_vec > flipped * thresholds, 1, 0)
+
     output['component_thresholds'] = thresholds
+    output['binary_threshold_spatial'] = binary_ICs
     return output
 
 def noise_SD_threshold(components: dict, thresh: float = 3) -> dict:


### PR DESCRIPTION
Updates seas.ica.rebuild()
- New options as described in docstrings, of note:
- New options for 'filter_method', incl. 'constant'
- New option 'apply_component_filter', which applies a butterworth lowpass filter to IC timecourses before rebuilding video. lpf threshold determined using 'chigh' option.
- New option 'apply_masked_mean' for use with thresholded ICs.

New function seas.domains.threshold_by_domains()
- Optional function to spatially threshold ICs in various ways. Use alongside 'apply_masked_mean' above to selectively rebuild IC videos. Docstrings cover options.